### PR TITLE
PLAT-55: Fix connect.record.doc check

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaProjector.java
@@ -129,7 +129,10 @@ public class SchemaProjector {
             throw new SchemaProjectorException("Schema type mismatch. source type: " + source.type() + " and target type: " + target.type());
         } else if (!Objects.equals(source.name(), target.name())) {
             throw new SchemaProjectorException("Schema name mismatch. source name: " + source.name() + " and target name: " + target.name());
-        } else if (!Objects.equals(source.parameters(), target.parameters()) && !source.parameters().containsKey("io.confluent.connect.avro.Enum")) {
+        } else if (!Objects.equals(source.parameters(), target.parameters()) &&
+            !source.parameters().containsKey("io.confluent.connect.avro.Enum") &&
+            !source.parameters().containsKey("connect.record.doc")
+        ) {
             throw new SchemaProjectorException("Schema parameters not equal. source parameters: " + source.parameters() + " and target parameters: " + target.parameters());
         }
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
@@ -469,20 +469,32 @@ public class SchemaProjectorTest {
             // expected
         }
 
+        // Test Enum - By Flipp
         Map<String, String> sourceEnumParamters = new HashMap<String, String>();
         sourceEnumParamters.put("io.confluent.connect.avro.Enum", "FooEnum");
         sourceEnumParamters.put("io.confluent.connect.avro.Enum.FooSymbol", "FooSymbol");
-        Schema sourceWithEnumParameters = SchemaBuilder.string().parameters(sourceEnumParamters);
+        Schema sourceWithEnumParameters = SchemaBuilder.string().parameters(sourceEnumParamters).build();
 
         Map<String, String> targetEnumParamters = new HashMap<String, String>();
         targetEnumParamters.put("io.confluent.connect.avro.Enum", "FooEnum");
         targetEnumParamters.put("io.confluent.connect.avro.Enum.FooSymbol", "FooSymbol");
         targetEnumParamters.put("io.confluent.connect.avro.Enum.BarSymbol", "BarSymbol");
-        Schema targetWithEnumParameters = SchemaBuilder.string().parameters(targetEnumParamters);
+        Schema targetWithEnumParameters = SchemaBuilder.string().parameters(targetEnumParamters).build();
 
         Object projected = SchemaProjector.project(sourceWithEnumParameters, "FooSymbol", targetWithEnumParameters);
-
         assertEquals("FooSymbol", projected);
+
+        // Test Record Doc - By Flipp
+        Map<String, String> sourceRecordDocParamters = new HashMap<String, String>();
+        sourceRecordDocParamters.put("connect.record.doc", "This is first version");
+        Schema sourceWithRecordDocParamters = SchemaBuilder.string().parameters(sourceRecordDocParamters).build();
+
+        Map<String, String> targetRecordDocParamters = new HashMap<String, String>();
+        targetRecordDocParamters.put("connect.record.doc", "This is second version");
+        Schema targetWithRecordDocParameters = SchemaBuilder.string().parameters(targetRecordDocParamters).build();
+
+        Object projectedObj = SchemaProjector.project(sourceWithRecordDocParamters, "ProjectedObj", targetWithRecordDocParameters);
+        assertEquals("ProjectedObj", projectedObj);
     }
 
     @Test


### PR DESCRIPTION
Change the connect component so that if there is a change in the `doc` part of the schema, it will not fail the compatibility check anymore.
